### PR TITLE
Changed directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@
          && rm -rf /var/www/html \
          && git clone https://github.com/rathena/FluxCP.git /var/www/html \
          && git clone https://github.com/rathena/rathena.git /usr/bin/rathena \
+         && cd rathena \
          && ./configure --enable-packetver=20151104 \
          && make server \
          && service mysql start \


### PR DESCRIPTION
After cloning the rathena project into the default folder which is `rathena`, the current directory must be moved inside the folder before performing the next operation which is configuring and making the server.